### PR TITLE
Feature/emissions api

### DIFF
--- a/processFlows.dscp
+++ b/processFlows.dscp
@@ -21,7 +21,6 @@ token IssuedCert {
   energy_owner: Role,
   regulator: Role,
   embodied_co2: Literal,
-  energy_source: "grid" | "renewable",
 }
 
 token RevokedCert {

--- a/processFlows.json
+++ b/processFlows.json
@@ -332,34 +332,6 @@
       },
       {
         "Restriction": {
-          "FixedOutputMetadataValue": {
-            "index": 0,
-            "metadata_key": "energy_source",
-            "metadata_value": {
-              "Literal": "renewable"
-            }
-          }
-        }
-      },
-      {
-        "Restriction": {
-          "FixedOutputMetadataValue": {
-            "index": 0,
-            "metadata_key": "energy_source",
-            "metadata_value": {
-              "Literal": "grid"
-            }
-          }
-        }
-      },
-      {
-        "Op": "Or"
-      },
-      {
-        "Op": "And"
-      },
-      {
-        "Restriction": {
           "MatchInputOutputMetadataValue": {
             "input_index": 0,
             "input_metadata_key": "@original_id",
@@ -617,34 +589,6 @@
             "metadata_value_type": "Literal"
           }
         }
-      },
-      {
-        "Op": "And"
-      },
-      {
-        "Restriction": {
-          "FixedInputMetadataValue": {
-            "index": 0,
-            "metadata_key": "energy_source",
-            "metadata_value": {
-              "Literal": "renewable"
-            }
-          }
-        }
-      },
-      {
-        "Restriction": {
-          "FixedInputMetadataValue": {
-            "index": 0,
-            "metadata_key": "energy_source",
-            "metadata_value": {
-              "Literal": "grid"
-            }
-          }
-        }
-      },
-      {
-        "Op": "Or"
       },
       {
         "Op": "And"

--- a/src/controllers/v1/certificate/index.ts
+++ b/src/controllers/v1/certificate/index.ts
@@ -336,24 +336,20 @@ export class CertificateController extends Controller {
       throw new BadRequest('can only issue certificates with a valid commitment')
 
     let embodied_co2: number
-    let energy_source: 'grid' | 'renewable'
-    if (!('embodied_co2' in body)) {
+    if (body.embodied_co2 !== undefined) {
+      embodied_co2 = body.embodied_co2
+    } else {
       embodied_co2 = await this.emissionCalculator.fetchEmissions(
         certificate.production_start_time,
         certificate.production_end_time,
         certificate.energy_consumed_mwh
       )
-      energy_source = 'grid'
-    } else {
-      embodied_co2 = body.embodied_co2
-      energy_source = body.energy_source
     }
 
     const extrinsic = await this.node.prepareRunProcess(
       processIssueCert({
         ...certificate,
         embodied_co2,
-        energy_source,
       })
     )
     const [transaction] = await this.db.insert('transaction', {

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -79,7 +79,6 @@ const certificateRowZ = insertCertificateRowZ.extend({
   created_at: z.date(),
   updated_at: z.date(),
   embodied_co2: z.union([z.number(), z.null()]),
-  energy_source: z.union([z.literal('grid'), z.literal('renewable'), z.null()]),
 })
 
 export type InsertCertificateRow = z.infer<typeof insertCertificateRowZ>

--- a/src/lib/db/migrations/20230310111029_initial.ts
+++ b/src/lib/db/migrations/20230310111029_initial.ts
@@ -22,13 +22,6 @@ export async function up(knex: Knex): Promise<void> {
     def.uuid('id').defaultTo(knex.raw('uuid_generate_v4()'))
     def.integer('hydrogen_quantity_mwh').notNullable().index('hydrogen_quantity_mwh_index')
     def.integer('embodied_co2').nullable().index('embodied_co2_index').defaultTo(null)
-    def
-      .enum('energy_source', ['grid', 'renewable'], {
-        useNative: true,
-        enumName: 'energy_source',
-      })
-      .nullable()
-      .defaultTo(null)
     def.string('energy_owner', 48).notNullable()
     def.string('hydrogen_owner', 48).notNullable()
     def.string('regulator', 48).notNullable()
@@ -94,6 +87,5 @@ export async function down(knex: Knex): Promise<void> {
   await knex.raw('DROP TYPE transaction_state')
   await knex.raw('DROP TYPE transaction_type')
   await knex.raw('DROP TYPE api_type')
-  await knex.raw('DROP TYPE energy_source')
   await knex.raw('DROP EXTENSION "uuid-ossp"')
 }

--- a/src/lib/indexer/__tests__/eventProcessor.test.ts
+++ b/src/lib/indexer/__tests__/eventProcessor.test.ts
@@ -111,10 +111,7 @@ describe('eventProcessor', function () {
         outputs: [
           {
             id: 2,
-            metadata: new Map([
-              ['embodied_co2', '42'],
-              ['energy_source', 'grid'],
-            ]),
+            metadata: new Map([['embodied_co2', '42']]),
             roles: new Map(),
           },
         ],
@@ -130,14 +127,13 @@ describe('eventProcessor', function () {
               latest_token_id: 2,
               state: 'issued',
               embodied_co2: 42,
-              energy_source: 'grid',
             },
           ],
         ]),
       })
     })
 
-    it('should throw if embodies_co2 is missing', function () {
+    it('should throw if embodied_co2 is missing', function () {
       let error: Error | null = null
       try {
         eventProcessors['issue_cert']({
@@ -147,7 +143,7 @@ describe('eventProcessor', function () {
           outputs: [
             {
               id: 2,
-              metadata: new Map([['energy_source', 'grid']]),
+              metadata: new Map([]),
               roles: new Map(),
             },
           ],
@@ -158,7 +154,7 @@ describe('eventProcessor', function () {
       expect(error).to.empty.instanceOf(Error)
     })
 
-    it('should throw if embodies_co2 is not a number', function () {
+    it('should throw if embodied_co2 is not a number', function () {
       let error: Error | null = null
       try {
         eventProcessors['issue_cert']({
@@ -168,34 +164,7 @@ describe('eventProcessor', function () {
           outputs: [
             {
               id: 2,
-              metadata: new Map([
-                ['embodied_co2', 'string'],
-                ['energy_source', 'grid'],
-              ]),
-              roles: new Map(),
-            },
-          ],
-        })
-      } catch (e) {
-        if (e instanceof Error) error = e
-      }
-      expect(error).to.empty.instanceOf(Error)
-    })
-
-    it('should throw if energy_source is not grid or renewable', function () {
-      let error: Error | null = null
-      try {
-        eventProcessors['issue_cert']({
-          version: 1,
-          sender: 'alice',
-          inputs: [{ id: 1, local_id: 'caa699b7-b0b6-4e0e-ac15-698b7b1f6541' }],
-          outputs: [
-            {
-              id: 2,
-              metadata: new Map([
-                ['embodied_co2', '42'],
-                ['energy_source', 'string'],
-              ]),
+              metadata: new Map([['embodied_co2', 'string']]),
               roles: new Map(),
             },
           ],

--- a/src/lib/indexer/changeSet.ts
+++ b/src/lib/indexer/changeSet.ts
@@ -28,7 +28,6 @@ export type CertificateRecord =
       id: UUID
       state: 'pending' | 'initiated' | 'issued' | 'revoked'
       embodied_co2?: number
-      energy_source?: 'grid' | 'renewable'
       original_token_id?: number
       latest_token_id: number
     }

--- a/src/lib/indexer/eventProcessor.ts
+++ b/src/lib/indexer/eventProcessor.ts
@@ -95,11 +95,6 @@ const DefaultEventProcessors: EventProcessors = {
     const { local_id } = inputs[0]
     const { id: latest_token_id, ...cert } = outputs[0]
 
-    const energy_source = getOrError(cert.metadata, 'energy_source')
-
-    if (energy_source !== 'grid' && energy_source !== 'renewable') {
-      throw new Error(`Energy source ${energy_source} is invalid`)
-    }
     const embodied_co2 = parseFloat(getOrError(cert.metadata, 'embodied_co2'))
     if (!Number.isFinite(embodied_co2)) {
       throw new Error(`Invalid value for embodied co2 ${embodied_co2}`)
@@ -111,7 +106,6 @@ const DefaultEventProcessors: EventProcessors = {
       latest_token_id,
       state: 'issued',
       embodied_co2,
-      energy_source,
     }
 
     return {

--- a/src/lib/payload.ts
+++ b/src/lib/payload.ts
@@ -53,7 +53,6 @@ export const processIssueCert = (certificate: CertificateRow): Payload => ({
         '@type': { type: 'LITERAL', value: 'IssuedCert' },
         '@original_id': { type: 'TOKEN_ID', value: certificate.original_token_id || Number.NaN },
         embodied_co2: { type: 'LITERAL', value: `${certificate.embodied_co2}` },
-        energy_source: { type: 'LITERAL', value: `${certificate.energy_source}` },
       },
     },
   ],

--- a/src/models/certificate.ts
+++ b/src/models/certificate.ts
@@ -8,7 +8,6 @@ export type GetCertificateResponse = {
   regulator: string
   hydrogen_quantity_mwh: number
   embodied_co2?: number | null
-  energy_source?: 'grid' | 'renewable' | null
   original_token_id?: number | null
   latest_token_id?: number | null
   created_at: Date
@@ -57,9 +56,6 @@ export type UpdatePayload = {
   commitment_salt: string
 }
 
-export type IssuancePayload =
-  | {
-      embodied_co2: number
-      energy_source: 'grid' | 'renewable'
-    }
-  | Record<string, never>
+export type IssuancePayload = {
+  embodied_co2?: number
+}

--- a/test/integration/onchain/certificate.test.ts
+++ b/test/integration/onchain/certificate.test.ts
@@ -99,7 +99,6 @@ describe('on-chain', function () {
 
         const response = await post(context.app, `/v1/certificate/${context.cert.id}/issuance`, {
           embodied_co2: 3,
-          energy_source: 'renewable',
         })
         expect(response.status).to.equal(201)
 
@@ -116,7 +115,6 @@ describe('on-chain', function () {
           id: context.cert.id,
           state: 'issued',
           embodied_co2: 3,
-          energy_source: 'renewable',
           latest_token_id: lastTokenId + 1,
         })
       })
@@ -142,7 +140,6 @@ describe('on-chain', function () {
           id: context.cert.id,
           state: 'issued',
           embodied_co2: 200000,
-          energy_source: 'grid',
           latest_token_id: lastTokenId + 1,
         })
       })


### PR DESCRIPTION
resolves #19

This PR makes the `embodied_co2` argument on the `issuance` transaction API optional. If it is not provided we automatically fetch the relevant data from https://api.carbonintensity.org.uk/ . Note the resolution of #19 is done as a bonus