### PR TITLE
Set default IPFS swarm key at startup

### DIFF
--- a/docker/ipfs.yml
+++ b/docker/ipfs.yml
@@ -31,6 +31,10 @@ services:
       ./app/index.js;'
     environment:
       - NODE_HOST=hydrogen-producer-node
+      - |
+        IPFS_SWARM_KEY=/key/swarm/psk/1.0.0/
+        /base16/
+        0000000000000000000000000000000000000000000000000000000000000000
     volumes:
       - hydrogen-producer-ipfs:/ipfs
     restart: on-failure
@@ -61,6 +65,10 @@ services:
       ./app/index.js;'
     environment:
       - NODE_HOST=energy-owner-node
+      - |
+        IPFS_SWARM_KEY=/key/swarm/psk/1.0.0/
+        /base16/
+        0000000000000000000000000000000000000000000000000000000000000000
     volumes:
       - energy-owner-ipfs:/ipfs
     restart: on-failure
@@ -91,6 +99,10 @@ services:
       ./app/index.js;'
     environment:
       - NODE_HOST=regulator-node
+      - |
+        IPFS_SWARM_KEY=/key/swarm/psk/1.0.0/
+        /base16/
+        0000000000000000000000000000000000000000000000000000000000000000
     volumes:
       - regulator-ipfs:/ipfs
     restart: on-failure

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-hyproof-api",
-  "version": "0.12.16",
+  "version": "0.12.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-hyproof-api",
-      "version": "0.12.16",
+      "version": "0.12.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-hyproof-api",
-  "version": "0.12.16",
+  "version": "0.12.17",
   "description": "An OpenAPI API service for SQNC",
   "main": "src/index.ts",
   "type": "module",


### PR DESCRIPTION
Setting a default IPFS swarm key (`0x0` here) in the docker-compose environment to try to fix IPFS containers sporadically failing to initialise
