### PR TITLE
Upgrade tsoa so it now builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@polkadot/api": "^10.12.1",
         "@polkadot/util-crypto": "^12.6.2",
-        "@tsoa/runtime": "^6.0.0",
+        "@tsoa/runtime": "^6.1.5",
         "base-x": "^4.0.0",
         "body-parser": "^1.20.2",
         "cors": "^2.8.5",
@@ -25,7 +25,7 @@
         "pino": "^8.19.0",
         "reflect-metadata": "^0.2.1",
         "swagger-ui-express": "^5.0.0",
-        "tsoa": "^6.0.1",
+        "tsoa": "^6.1.5",
         "tsyringe": "^4.8.0",
         "uuid": "^9.0.1",
         "zod": "^3.22.4"
@@ -537,6 +537,293 @@
       "dev": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@hapi/accept": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-6.0.3.tgz",
+      "integrity": "sha512-p72f9k56EuF0n3MwlBNThyVE5PXX40g+aQh+C/xbKrfzahM2Oispv3AXmOIU51t3j77zay1qrX7IIziZXspMlw==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/ammo": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-6.0.1.tgz",
+      "integrity": "sha512-pmL+nPod4g58kXrMcsGLp05O2jF4P2Q3GiL8qYV7nKYEh3cGf+rV4P5Jyi2Uq0agGhVU63GtaSAfBEZOlrJn9w==",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/b64": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-6.0.1.tgz",
+      "integrity": "sha512-ZvjX4JQReUmBheeCq+S9YavcnMMHWqx3S0jHNXWIM1kQDxB9cyfSycpVvjfrKcIS8Mh5N3hmu/YKo4Iag9g2Kw==",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/boom": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
+      "integrity": "sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/bounce": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.1.tgz",
+      "integrity": "sha512-G+/Pp9c1Ha4FDP+3Sy/Xwg2O4Ahaw3lIZFSX+BL4uWi64CmiETuZPxhKDUD4xBMOUZbBlzvO8HjiK8ePnhBadA==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/bourne": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w=="
+    },
+    "node_modules/@hapi/call": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-9.0.1.tgz",
+      "integrity": "sha512-uPojQRqEL1GRZR4xXPqcLMujQGaEpyVPRyBlD8Pp5rqgIwLhtveF9PkixiKru2THXvuN8mUrLeet5fqxKAAMGg==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/catbox": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-12.1.1.tgz",
+      "integrity": "sha512-hDqYB1J+R0HtZg4iPH3LEnldoaBsar6bYp0EonBmNQ9t5CO+1CqgCul2ZtFveW1ReA5SQuze9GPSU7/aecERhw==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/podium": "^5.0.0",
+        "@hapi/validate": "^2.0.1"
+      }
+    },
+    "node_modules/@hapi/catbox-memory": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-6.0.1.tgz",
+      "integrity": "sha512-sVb+/ZxbZIvaMtJfAbdyY+QJUQg9oKTwamXpEg/5xnfG5WbJLTjvEn4kIGKz9pN3ENNbIL/bIdctmHmqi/AdGA==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/content": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
+      "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.0"
+      }
+    },
+    "node_modules/@hapi/cryptiles": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-6.0.1.tgz",
+      "integrity": "sha512-9GM9ECEHfR8lk5ASOKG4+4ZsEzFqLfhiryIJ2ISePVB92OHLp/yne4m+zn7z9dgvM98TLpiFebjDFQ0UHcqxXQ==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/file": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-3.0.0.tgz",
+      "integrity": "sha512-w+lKW+yRrLhJu620jT3y+5g2mHqnKfepreykvdOcl9/6up8GrQQn+l3FRTsjHTKbkbfQFkuksHpdv2EcpKcJ4Q=="
+    },
+    "node_modules/@hapi/hapi": {
+      "version": "21.3.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-21.3.7.tgz",
+      "integrity": "sha512-33J0nreMfqkhY7wwRAZRy+9J+7J4QOH1JtICMjIUmxfaOYSJL/d8JJCtg57SX60944bhlCeu7isb7qyr2jT2oA==",
+      "dependencies": {
+        "@hapi/accept": "^6.0.1",
+        "@hapi/ammo": "^6.0.1",
+        "@hapi/boom": "^10.0.1",
+        "@hapi/bounce": "^3.0.1",
+        "@hapi/call": "^9.0.1",
+        "@hapi/catbox": "^12.1.1",
+        "@hapi/catbox-memory": "^6.0.1",
+        "@hapi/heavy": "^8.0.1",
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/mimos": "^7.0.1",
+        "@hapi/podium": "^5.0.1",
+        "@hapi/shot": "^6.0.1",
+        "@hapi/somever": "^4.1.1",
+        "@hapi/statehood": "^8.1.1",
+        "@hapi/subtext": "^8.1.0",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/topo": "^6.0.1",
+        "@hapi/validate": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      }
+    },
+    "node_modules/@hapi/heavy": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-8.0.1.tgz",
+      "integrity": "sha512-gBD/NANosNCOp6RsYTsjo2vhr5eYA3BEuogk6cxY0QdhllkkTaJFYtTXv46xd6qhBVMbMMqcSdtqey+UQU3//w==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/validate": "^2.0.1"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.4.tgz",
+      "integrity": "sha512-PnsP5d4q7289pS2T2EgGz147BFJ2Jpb4yrEdkpz2IhgEUzos1S7HTl7ezWh1yfYzYlj89KzLdCRkqsP6SIryeQ=="
+    },
+    "node_modules/@hapi/iron": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-7.0.1.tgz",
+      "integrity": "sha512-tEZnrOujKpS6jLKliyWBl3A9PaE+ppuL/+gkbyPPDb/l2KSKQyH4lhMkVb+sBhwN+qaxxlig01JRqB8dk/mPxQ==",
+      "dependencies": {
+        "@hapi/b64": "^6.0.1",
+        "@hapi/boom": "^10.0.1",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/mimos": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-7.0.1.tgz",
+      "integrity": "sha512-b79V+BrG0gJ9zcRx1VGcCI6r6GEzzZUgiGEJVoq5gwzuB2Ig9Cax8dUuBauQCFKvl2YWSWyOc8mZ8HDaJOtkew==",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2",
+        "mime-db": "^1.52.0"
+      }
+    },
+    "node_modules/@hapi/nigel": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-5.0.1.tgz",
+      "integrity": "sha512-uv3dtYuB4IsNaha+tigWmN8mQw/O9Qzl5U26Gm4ZcJVtDdB1AVJOwX3X5wOX+A07qzpEZnOMBAm8jjSqGsU6Nw==",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/vise": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/pez": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-6.1.0.tgz",
+      "integrity": "sha512-+FE3sFPYuXCpuVeHQ/Qag1b45clR2o54QoonE/gKHv9gukxQ8oJJZPR7o3/ydDTK6racnCJXxOyT1T93FCJMIg==",
+      "dependencies": {
+        "@hapi/b64": "^6.0.1",
+        "@hapi/boom": "^10.0.1",
+        "@hapi/content": "^6.0.0",
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/nigel": "^5.0.1"
+      }
+    },
+    "node_modules/@hapi/podium": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-5.0.1.tgz",
+      "integrity": "sha512-eznFTw6rdBhAijXFIlBOMJJd+lXTvqbrBIS4Iu80r2KTVIo4g+7fLy4NKp/8+UnSt5Ox6mJtAlKBU/Sf5080TQ==",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/teamwork": "^6.0.0",
+        "@hapi/validate": "^2.0.1"
+      }
+    },
+    "node_modules/@hapi/shot": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-6.0.1.tgz",
+      "integrity": "sha512-s5ynMKZXYoDd3dqPw5YTvOR/vjHvMTxc388+0qL0jZZP1+uwXuUD32o9DuuuLsmTlyXCWi02BJl1pBpwRuUrNA==",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/validate": "^2.0.1"
+      }
+    },
+    "node_modules/@hapi/somever": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-4.1.1.tgz",
+      "integrity": "sha512-lt3QQiDDOVRatS0ionFDNrDIv4eXz58IibQaZQDOg4DqqdNme8oa0iPWcE0+hkq/KTeBCPtEOjDOBKBKwDumVg==",
+      "dependencies": {
+        "@hapi/bounce": "^3.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/statehood": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-8.1.1.tgz",
+      "integrity": "sha512-YbK7PSVUA59NArAW5Np0tKRoIZ5VNYUicOk7uJmWZF6XyH5gGL+k62w77SIJb0AoAJ0QdGQMCQ/WOGL1S3Ydow==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/bounce": "^3.0.1",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/cryptiles": "^6.0.1",
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/iron": "^7.0.1",
+        "@hapi/validate": "^2.0.1"
+      }
+    },
+    "node_modules/@hapi/subtext": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-8.1.0.tgz",
+      "integrity": "sha512-PyaN4oSMtqPjjVxLny1k0iYg4+fwGusIhaom9B2StinBclHs7v46mIW706Y+Wo21lcgulGyXbQrmT/w4dus6ww==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/content": "^6.0.0",
+        "@hapi/file": "^3.0.0",
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/pez": "^6.1.0",
+        "@hapi/wreck": "^18.0.1"
+      }
+    },
+    "node_modules/@hapi/teamwork": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-6.0.0.tgz",
+      "integrity": "sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/validate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.1.tgz",
+      "integrity": "sha512-NZmXRnrSLK8MQ9y/CMqE9WSspgB9xA41/LlYR0k967aSZebWr4yNrpxIbov12ICwKy4APSlWXZga9jN5p6puPA==",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/topo": "^6.0.1"
+      }
+    },
+    "node_modules/@hapi/vise": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-5.0.1.tgz",
+      "integrity": "sha512-XZYWzzRtINQLedPYlIkSkUr7m5Ddwlu99V9elh8CSygXstfv3UnWIXT0QD+wmR0VAG34d2Vx3olqcEhRRoTu9A==",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/wreck": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.0.1.tgz",
+      "integrity": "sha512-OLHER70+rZxvDl75xq3xXOfd3e8XIvz8fWY0dqg92UvhZ29zo24vQgfqgHSYhB5ZiuFpSLeriOisAlxAo/1jWg==",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/bourne": "^3.0.0",
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1495,21 +1782,21 @@
       "dev": true
     },
     "node_modules/@tsoa/cli": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@tsoa/cli/-/cli-6.0.1.tgz",
-      "integrity": "sha512-SpdWPIzAtfG6Jcb6KIvT4VVo9VnAfAiY6+dCrrlKURlEfah05rRQ7k09jeJdAZoeeoKVwyJNj+43zlh9w1u7bg==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@tsoa/cli/-/cli-6.1.5.tgz",
+      "integrity": "sha512-o+1pd03pUAwneoHX2PPWjxGJe5+yQ+PD5+z7gJ/Fvl0qi46hAO6UXc/UDQ09S8PW333rN49V164EYWgdT4xjtQ==",
       "dependencies": {
-        "@tsoa/runtime": "^6.0.0",
+        "@tsoa/runtime": "^6.1.5",
         "@types/multer": "^1.4.11",
-        "deepmerge": "^4.3.1",
         "fs-extra": "^11.2.0",
         "glob": "^10.3.10",
         "handlebars": "^4.7.8",
         "merge-anything": "^5.1.4",
         "minimatch": "^9.0.1",
+        "ts-deepmerge": "^7.0.0",
         "typescript": "^5.3.3",
         "validator": "^13.11.0",
-        "yamljs": "^0.3.0",
+        "yaml": "^2.4.1",
         "yargs": "^17.7.1"
       },
       "bin": {
@@ -1555,18 +1842,41 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@tsoa/cli/node_modules/yaml": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.1.tgz",
+      "integrity": "sha512-pIXzoImaqmfOrL7teGUBt/T7ZDnyeGBWyXQBvOVhLkWLN37GXv8NMLK406UY6dS51JfcQHsmcW5cJ441bHg6Lg==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@tsoa/runtime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@tsoa/runtime/-/runtime-6.0.0.tgz",
-      "integrity": "sha512-n0LYcjII313kDn3M4bZdAjU+sX7595sIEA3bw4pvxWRrkandyDdDFNrfQL8nZ3Pw6dkTmK7brZi0YBBDhe0Rzw==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@tsoa/runtime/-/runtime-6.1.5.tgz",
+      "integrity": "sha512-UxS9k5mwlys6CbBixda4SsJ/D8hfta919yH8fALHOxnfN9nFXU9rKAfvjHDTpCQ/ZTiR46yrMZMN4jyV0n9miQ==",
       "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hapi": "^21.3.3",
+        "@types/koa": "^2.15.0",
         "@types/multer": "^1.4.11",
+        "express": "^4.18.3",
         "reflect-metadata": "^0.2.1",
         "validator": "^13.11.0"
       },
       "engines": {
         "node": ">=18.0.0",
         "yarn": ">=1.9.4"
+      }
+    },
+    "node_modules/@types/accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/bn.js": {
@@ -1600,11 +1910,27 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/content-disposition": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.8.tgz",
+      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg=="
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true
+    },
+    "node_modules/@types/cookies": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.0.tgz",
+      "integrity": "sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/cors": {
       "version": "2.8.17",
@@ -1637,6 +1963,11 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/http-assert": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.5.tgz",
+      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g=="
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
@@ -1647,6 +1978,34 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
+    },
+    "node_modules/@types/keygrip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
+      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ=="
+    },
+    "node_modules/@types/koa": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
+      "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
+      "dependencies": {
+        "@types/accepts": "*",
+        "@types/content-disposition": "*",
+        "@types/cookies": "*",
+        "@types/http-assert": "*",
+        "@types/http-errors": "*",
+        "@types/keygrip": "*",
+        "@types/koa-compose": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/koa-compose": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.8.tgz",
+      "integrity": "sha512-4Olc63RY+MKvxMwVknCUDhRQX1pFQoBZ/lXcRLP69PQkEpze/0cr8LNqJQe5NFb/b19DWi2a5bTi2VAlQzhJuA==",
+      "dependencies": {
+        "@types/koa": "*"
+      }
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -2204,6 +2563,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -2663,7 +3023,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -2862,14 +3223,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/default-browser": {
       "version": "4.0.0",
@@ -3858,7 +4211,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3942,6 +4296,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3973,6 +4328,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3982,6 +4338,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4292,6 +4649,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5417,6 +5775,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5575,6 +5934,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6804,7 +7164,8 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -7120,6 +7481,14 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-deepmerge": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ts-deepmerge/-/ts-deepmerge-7.0.0.tgz",
+      "integrity": "sha512-WZ/iAJrKDhdINv1WG6KZIGHrZDar6VfhftG1QJFpVbOYZMYJLJOvZOo1amictRXVdBXZIgBHKswMTXzElngprA==",
+      "engines": {
+        "node": ">=14.13.1"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -7286,12 +7655,12 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsoa": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tsoa/-/tsoa-6.0.1.tgz",
-      "integrity": "sha512-Far5BFpFvMYVMZxt87O7hOFGpa6dALQ8XHhdDytry0IhIUJnRliVXLZ2t2KGcgNw0bIwsk+2XkWra18LL6cORA==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/tsoa/-/tsoa-6.1.5.tgz",
+      "integrity": "sha512-J+nNeGA2nsYGpgpLgmOjP7rIYR/Hu6iQzTwPp2D1iZbGKt7S5TIqA02/1BfGuY/9tpIkq4uZMpJ9i37plprTsw==",
       "dependencies": {
-        "@tsoa/cli": "^6.0.1",
-        "@tsoa/runtime": "^6.0.0"
+        "@tsoa/cli": "^6.1.5",
+        "@tsoa/runtime": "^6.1.5"
       },
       "bin": {
         "tsoa": "dist/cli.js"
@@ -7570,7 +7939,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/ws": {
       "version": "8.16.0",
@@ -7621,19 +7991,6 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/yamljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
-      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "glob": "^7.0.5"
-      },
-      "bin": {
-        "json2yaml": "bin/json2yaml",
-        "yaml2json": "bin/yaml2json"
       }
     },
     "node_modules/yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/sqnc-hyproof-api",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/sqnc-hyproof-api",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/api": "^10.12.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@polkadot/api": "^10.12.1",
     "@polkadot/util-crypto": "^12.6.2",
-    "@tsoa/runtime": "^6.0.0",
+    "@tsoa/runtime": "^6.1.5",
     "base-x": "^4.0.0",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
@@ -88,7 +88,7 @@
     "pino": "^8.19.0",
     "reflect-metadata": "^0.2.1",
     "swagger-ui-express": "^5.0.0",
-    "tsoa": "^6.0.1",
+    "tsoa": "^6.1.5",
     "tsyringe": "^4.8.0",
     "uuid": "^9.0.1",
     "zod": "^3.22.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/sqnc-hyproof-api",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "An OpenAPI API service for SQNC",
   "main": "src/index.ts",
   "type": "module",

--- a/src/controllers/v1/certificate/index.ts
+++ b/src/controllers/v1/certificate/index.ts
@@ -115,15 +115,17 @@ export class CertificateController extends Controller {
   @SuccessResponse('201')
   public async postDraft(
     @Body()
-    {
+    body: InitiatePayload
+  ): Promise<GetCertificateResponse> {
+    const {
       hydrogen_quantity_wh,
       energy_owner,
       regulator,
       production_start_time,
       production_end_time,
       energy_consumed_wh,
-    }: InitiatePayload
-  ): Promise<GetCertificateResponse> {
+    } = body
+
     this.log.trace({ identity: this.identity, energy_owner, regulator })
 
     if (production_end_time <= production_start_time) {
@@ -221,10 +223,8 @@ export class CertificateController extends Controller {
   @Response<NotFound>(404, '<item> not found')
   @Response<BadRequest>(400, 'ID must be a UUID or a positive integer')
   @Put('{id}')
-  public async updateById(
-    @Path() id: UUID | INT,
-    @Body() { commitment_salt, ...update }: UpdatePayload
-  ): Promise<GetCertificateResponse> {
+  public async updateById(@Path() id: UUID | INT, @Body() body: UpdatePayload): Promise<GetCertificateResponse> {
+    const { commitment_salt, ...update } = body
     if (!id) throw new BadRequest()
 
     const certificate = await this.getCertificate(id)
@@ -471,10 +471,8 @@ export class CertificateController extends Controller {
   @Post('{id}/revocation')
   @Response<NotFound>(404, 'Item not found')
   @SuccessResponse('201')
-  public async revokeOnChain(
-    @Path() id: UUID | INT,
-    @Body() { reason }: RevokePayload
-  ): Promise<GetTransactionResponse> {
+  public async revokeOnChain(@Path() id: UUID | INT, @Body() body: RevokePayload): Promise<GetTransactionResponse> {
+    const { reason } = body
     const { address: self_address } = await this.identity.getMemberBySelf()
 
     const certificate = await this.getCertificate(id)

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,6 +51,12 @@ export default async (): Promise<Express> => {
   app.use(bodyParser.urlencoded({ extended: true }))
   app.use(bodyParser.json())
   app.use(cors())
+  app.use((req, _, next) => {
+    // make sure we always have a file object on req even if this is not a multipart body this is so that
+    // the attachment route can handle both JSON and multipart bodies
+    req.files = []
+    next()
+  })
 
   RegisterRoutes(app)
   app.use(errorHandler)


### PR DESCRIPTION
Updates tsoa to latest. Note there's a couple of specfic changes here that are needed"

1. All body parameters must now be named and cannot be destructured in the method args. This is just now part of the type check from tsoa and is pretty straightforward
2. I've introduced a new middleware to always populate `files` on a body as `[]`. This is needed because tsoa quite reasonably assumes that only multipart bodies will have files. Probably the better long term solution is to split the attachment route but this gets us around the issue  without a breaking change